### PR TITLE
why not get rid of removed pkg's dependencies

### DIFF
--- a/Arch/arch-setup.sh
+++ b/Arch/arch-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-sudo pacman -R firefox libreoffice-fresh --noconfirm
+sudo pacman -Rns firefox libreoffice-fresh --noconfirm
 sudo pacman -Syu --noconfirm
-sudo pacman -S  discord lutris steam kdenlive gimp krita inkscape wine neofetch qbittorrent
+sudo pacman -S discord lutris steam kdenlive gimp krita inkscape wine neofetch qbittorrent
 git clone 
 
 # Unfinished for now, will come back


### PR DESCRIPTION
pacman -Rns gets rid of all the unique dependencies these packages required; aka it cleans bloat.